### PR TITLE
Add docstring and comments for TimeBind refresh operator

### DIFF
--- a/SkybrushUtil.py
+++ b/SkybrushUtil.py
@@ -281,6 +281,8 @@ class TIMEBIND_OT_entry_move(bpy.types.Operator):
         return {'FINISHED'}
     
 class TIMEBIND_OT_refresh(bpy.types.Operator):
+    """Recalculate frame offsets between storyboard and TimeBind entries
+    and update matching light-effect frame ranges."""
     bl_idname = "timebind.refresh"
     bl_label = "Refresh TimeBind"
 
@@ -296,14 +298,14 @@ class TIMEBIND_OT_refresh(bpy.types.Operator):
             # Storyboardエントリ検索
             for sb_entry in storyboard.entries:
                 if sb_entry.name.startswith(bind_entry.Prefix):
-                    # 差分計算
+                    # Calculate frame offset between storyboard and TimeBind entry
                     diff = sb_entry.frame_start - bind_entry.StartFrame
 
-                    # light_effectsのPrefix一致（startswith）
+                    # Apply the offset to light effect frame ranges with matching prefixes
                     for le_entry in light_effects.entries:
                         if le_entry.name.startswith(bind_entry.Prefix):
-                            le_entry.frame_start += diff
-                            le_entry.frame_end += diff
+                            le_entry.frame_start += diff  # shift start frame
+                            le_entry.frame_end += diff    # shift end frame
                     
                     update_texture_key(bind_entry.Prefix, diff)
                     if bind_entry.Prefix + "_Animated" in bpy.data.collections:


### PR DESCRIPTION
## Summary
- Document how the refresh operator recalculates frame offsets and updates light-effect ranges
- Clarify diff calculation and application to light-effect frames

## Testing
- `python -m py_compile SkybrushUtil.py`


------
https://chatgpt.com/codex/tasks/task_e_688c384970ac832f9debb96e8ccf1556