### PR TITLE
feat: add debug output for color keys

### DIFF
--- a/color_key_utils.py
+++ b/color_key_utils.py
@@ -1,6 +1,12 @@
 import bpy
 from mathutils import Vector
 
+# Optional import for debug image generation
+try:  # pragma: no cover - Pillow may not be available
+    from PIL import Image
+except Exception:  # pragma: no cover
+    Image = None
+
 
 def find_nearest_object(location, objects):
     """Return the object from ``objects`` nearest to ``location``."""
@@ -43,7 +49,13 @@ def apply_color_keys_to_nearest(location, keyframes_by_channel, available_object
     available_objects.remove(nearest_obj)
 
 
-def apply_color_keys_from_key_data(key_entries, start_frame=0, collection_name="Drones"):
+def apply_color_keys_from_key_data(
+    key_entries,
+    start_frame=0,
+    collection_name="Drones",
+    debug_image_path=None,
+    debug_object=None,
+):
     """Apply color keyframes for each entry using nearest drones.
 
     ``key_entries`` should be a list of dictionaries as produced by
@@ -51,18 +63,78 @@ def apply_color_keys_from_key_data(key_entries, start_frame=0, collection_name="
     of a track and its color keyframes. Keyframes are applied relative to
     ``start_frame`` and matched to the nearest objects found in the Blender
     collection named by ``collection_name``.
+
+    When ``debug_image_path`` is provided, an image visualising the RGB values
+    of all entries across time is written to that path.  When ``debug_object``
+    is provided, the color keys from the first entry are also applied to that
+    object's material for quick preview.
     """
     if not key_entries:
         return
+
+    # Apply to nearest drones in the specified collection
     drones_col = bpy.data.collections.get(collection_name)
-    if not drones_col:
-        return
-    available = list(drones_col.objects)
-    for entry in key_entries:
-        apply_color_keys_to_nearest(
-            entry["location"],
-            entry["keys"],
-            available,
-            frame_offset=start_frame,
-            normalize_255=True,
-        )
+    if drones_col:
+        available = list(drones_col.objects)
+        for entry in key_entries:
+            apply_color_keys_to_nearest(
+                entry["location"],
+                entry["keys"],
+                available,
+                frame_offset=start_frame,
+                normalize_255=True,
+            )
+
+    # Optionally apply keys to a provided debug object
+    if debug_object and key_entries:
+        mat = debug_object.active_material
+        if mat is None:
+            mat = bpy.data.materials.new(name="DebugColor")
+            mat.use_nodes = True
+            debug_object.data.materials.append(mat)
+        base_socket = None
+        for node in mat.node_tree.nodes:
+            if node.inputs and node.inputs[0].type == "RGBA":
+                base_socket = node.inputs[0]
+                break
+        if base_socket:
+            for channel, frames in key_entries[0]["keys"].items():
+                for frame, value in frames:
+                    base_socket.default_value[channel] = value / 255.0
+                    base_socket.keyframe_insert(
+                        "default_value", frame=frame + start_frame, index=channel
+                    )
+
+    # Optionally export RGB data as an image for debugging
+    if debug_image_path and Image and key_entries:
+        # Determine maximum frame across all entries
+        max_frame = 0
+        for entry in key_entries:
+            for frames in entry["keys"].values():
+                if frames:
+                    max_frame = max(max_frame, int(max(f for f, _ in frames)))
+        width = max_frame + 1
+        height = len(key_entries)
+        img = Image.new("RGB", (width, height))
+        pixels = img.load()
+        for y, entry in enumerate(key_entries):
+            # Prepare a color for each frame; default black
+            row = [[0, 0, 0] for _ in range(width)]
+            for ch in range(3):
+                frames = entry["keys"].get(ch, [])
+                if not frames:
+                    continue
+                frames = sorted(frames)
+                for i, (f0, v0) in enumerate(frames):
+                    f1, v1 = frames[i + 1] if i + 1 < len(frames) else (max_frame, v0)
+                    f0_i, f1_i = int(round(f0)), int(round(f1))
+                    for f in range(f0_i, f1_i + 1):
+                        t = 0 if f1_i == f0_i else (f - f0) / (f1 - f0)
+                        val = v0 + (v1 - v0) * t
+                        row[f][ch] = int(max(0, min(255, val)))
+            for x in range(width):
+                pixels[x, y] = tuple(row[x])
+        try:
+            img.save(debug_image_path)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- allow Debug Colors toggle to drive color key debugging without relying on Blender debug mode
- export RGB timeline image and apply preview color keys when Debug Colors is enabled

## Testing
- `python CSV2Vertex.py` *(fails: No module named 'bpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a9dbd57780832fb3ea4ffb97e96df2