### PR TITLE
Handle missing texture image in light effects

### DIFF
--- a/sbutil/light_effects.py
+++ b/sbutil/light_effects.py
@@ -176,9 +176,15 @@ class PatchedLightEffect(PropertyGroup):
             return outputs, common_output, order
         mapping_mode = getattr(mapping, "mode", None)
         if self.texture:
-            pixels = list(self.texture.image.pixels)
-            width = self.texture.image.size[0]
-            height = self.texture.image.size[1]
+            image = getattr(self.texture, "image", None)
+            if image:
+                pixels = list(image.pixels)
+                width = image.size[0]
+                height = image.size[1]
+            else:
+                pixels = None
+                width = 0
+                height = 0
         else:
             pixels = None
             width = 0


### PR DESCRIPTION
## Summary
- avoid AttributeError when light effects have a texture without an image

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac0fbbe714832fae56d728d46115d0