### PR TITLE
Remove color key debugging

### DIFF
--- a/sbutil/CSV2Vertex.py
+++ b/sbutil/CSV2Vertex.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.props import StringProperty, BoolProperty
+from bpy.props import StringProperty
 from bpy.types import Operator, Panel, PropertyGroup
 import csv, os, re, math
 
@@ -231,11 +231,6 @@ class CSVVA_Props(PropertyGroup):
         description="Folder containing CSV/TSV files with columns: Time[msec], x[m], y[m], z[m], Red, Green, Blue",
         subtype="DIR_PATH",
     )
-    debug: BoolProperty(
-        name="Debug Colors",
-        description="Output RGB timeline image and apply color keys to the imported mesh",
-        default=False,
-    )
 
 class CSVVA_OT_Import(Operator):
     bl_idname = "csvva.import_setup"
@@ -281,14 +276,9 @@ class CSVVA_OT_Import(Operator):
             for key_entries, sf, obj, sub_path in key_data_collection:
                 current_frame = context.scene.frame_current
                 context.scene.frame_set(sf)
-                debug_mode = prefs.debug
                 apply_color_keys_from_key_data(
                     key_entries,
                     sf,
-                    debug_image_path=(
-                        os.path.join(sub_path, f"{obj.name}_colors.png") if debug_mode else None
-                    ),
-                    debug_object=obj if debug_mode else None,
                 )
                 context.scene.frame_set(current_frame)
             self.report({"INFO"}, f"Setup complete for {len(created)} folders")
@@ -323,14 +313,9 @@ class CSVVA_OT_Import(Operator):
             pass
         current_frame = context.scene.frame_current
         context.scene.frame_set(start_frame)
-        debug_mode = prefs.debug
         apply_color_keys_from_key_data(
             key_entries,
             start_frame,
-            debug_image_path=(
-                os.path.join(folder, f"{obj.name}_colors.png") if debug_mode else None
-            ),
-            debug_object=obj if debug_mode else None,
         )
         context.scene.frame_set(current_frame)
         bpy.ops.object.select_all(action='DESELECT')
@@ -351,7 +336,6 @@ class CSVVA_PT_UI(Panel):
         prefs = context.scene.csvva_props
         col = lay.column(align=True)
         col.prop(prefs, "folder")
-        col.prop(prefs, "debug")
         col.operator(CSVVA_OT_Import.bl_idname, icon="IMPORT")
 
 

--- a/sbutil/color_key_utils.py
+++ b/sbutil/color_key_utils.py
@@ -1,12 +1,6 @@
 import bpy
 from mathutils import Vector
 
-# Optional import for debug image generation
-try:  # pragma: no cover - Pillow may not be available
-    from PIL import Image
-except Exception:  # pragma: no cover
-    Image = None
-
 
 def find_nearest_object(location, objects):
     """Return the object from ``objects`` nearest to ``location``."""
@@ -45,7 +39,6 @@ def _insert_color_keyframes(base_socket, keyframes_by_channel, frame_offset=0, n
         for idx, val in enumerate(current):
             base_socket.default_value[idx] = val
         base_socket.keyframe_insert("default_value", frame=frame + frame_offset)
-        print(current)
 
 def apply_color_keys_to_nearest(location, keyframes_by_channel, available_objects, frame_offset=0, normalize_255=False):
     """Find the nearest object to ``location`` and apply color keyframes.
@@ -82,8 +75,6 @@ def apply_color_keys_from_key_data(
     key_entries,
     start_frame=0,
     collection_name="Drones",
-    debug_image_path=None,
-    debug_object=None,
 ):
     """Apply color keyframes for each entry using nearest drones.
 
@@ -92,16 +83,10 @@ def apply_color_keys_from_key_data(
     of a track and its color keyframes. Keyframes are applied relative to
     ``start_frame`` and matched to the nearest objects found in the Blender
     collection named by ``collection_name``.
-
-    When ``debug_image_path`` is provided, an image visualising the RGB values
-    of all entries across time is written to that path.  When ``debug_object``
-    is provided, the color keys from the first entry are also applied to that
-    object's material for quick preview.
     """
     if not key_entries:
         return
 
-    # Apply to nearest drones in the specified collection
     drones_col = bpy.data.collections.get(collection_name)
     if drones_col:
         available = list(drones_col.objects)
@@ -114,56 +99,3 @@ def apply_color_keys_from_key_data(
                 normalize_255=True,
             )
 
-    # Optionally apply keys to a provided debug object
-    if debug_object and key_entries:
-        mat = debug_object.active_material
-        if mat is None:
-            mat = bpy.data.materials.new(name="DebugColor")
-            mat.use_nodes = True
-            debug_object.data.materials.append(mat)
-        base_socket = None
-        for node in mat.node_tree.nodes:
-            if node.inputs and node.inputs[0].type == "RGBA":
-                base_socket = node.inputs[0]
-                break
-        if base_socket:
-            _insert_color_keyframes(
-                base_socket,
-                key_entries[0]["keys"],
-                frame_offset=start_frame,
-                normalize_255=True,
-            )
-
-    # Optionally export RGB data as an image for debugging
-    if debug_image_path and Image and key_entries:
-        # Determine maximum frame across all entries
-        max_frame = 0
-        for entry in key_entries:
-            for frames in entry["keys"].values():
-                if frames:
-                    max_frame = max(max_frame, int(max(f for f, _ in frames)))
-        width = max_frame + 1
-        height = len(key_entries)
-        img = Image.new("RGB", (width, height))
-        pixels = img.load()
-        for y, entry in enumerate(key_entries):
-            # Prepare a color for each frame; default black
-            row = [[0, 0, 0] for _ in range(width)]
-            for ch in range(3):
-                frames = entry["keys"].get(ch, [])
-                if not frames:
-                    continue
-                frames = sorted(frames)
-                for i, (f0, v0) in enumerate(frames):
-                    f1, v1 = frames[i + 1] if i + 1 < len(frames) else (max_frame, v0)
-                    f0_i, f1_i = int(round(f0)), int(round(f1))
-                    for f in range(f0_i, f1_i + 1):
-                        t = 0 if f1_i == f0_i else (f - f0) / (f1 - f0)
-                        val = v0 + (v1 - v0) * t
-                        row[f][ch] = int(max(0, min(255, val)))
-            for x in range(width):
-                pixels[x, y] = tuple(row[x])
-        try:
-            img.save(debug_image_path)
-        except Exception:
-            pass


### PR DESCRIPTION
## Summary
- strip debug image/object features from color key utilities
- drop Debug Colors checkbox and related handling

## Testing
- `python -m py_compile sbutil/color_key_utils.py sbutil/CSV2Vertex.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac0f9f2ae8832f9afd832afbd32aa9