### PR TITLE
Add automatic add-on update operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Skybrush Util
+
+Blender add-on for transferring keyframes and light effects.
+
+## Updating
+
+In **Edit > Preferences > Add-ons**, open the Skybrush Util entry and use the
+**Update Add-on** button to automatically check GitHub for a newer release. If a
+newer version is available, it is downloaded, installed, and re-enabled inside
+Blender.


### PR DESCRIPTION
## Summary
- add `DRONE_OT_UpdateAddon` operator to fetch latest release from GitHub and reinstall add-on
- expose `Update Add-on` button in add-on preferences instead of SBUtil panel
- document update capability in README with preference location

## Testing
- `python -m py_compile SkybrushUtil.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad24eb0034832fa6c087c41a3a56d6