### PR TITLE
Show color picker for config variables ending with _COLOR

### DIFF
--- a/sbutil/light_effects.py
+++ b/sbutil/light_effects.py
@@ -92,7 +92,11 @@ def initialize_color_function(pg) -> None:
             ):
                 list_value = list(value)
                 pg[attr_name] = list_value
-                schema[attr_name] = {"default": list_value}
+                meta = {"default": list_value}
+                if name.endswith("_COLOR"):
+                    # Suffix indicates that the value should be shown as a color
+                    meta["subtype"] = "COLOR"
+                schema[attr_name] = meta
         st["config_schema"] = schema
 
 
@@ -460,6 +464,7 @@ def ensure_schema(pg, schema):
             ("min", "min"), ("max", "max"),
             ("soft_min", "soft_min"), ("soft_max", "soft_max"),
             ("desc", "description"),
+            ("subtype", "subtype"),
         ]:
             if k_src in meta:
                 ui_kwargs[k_dst] = meta[k_src]


### PR DESCRIPTION
## Summary
- Detect `_COLOR` variables in color function modules and mark them as color properties
- Allow dynamic property schema to specify `subtype` so Blender shows color UI widgets

## Testing
- `python -m py_compile sbutil/light_effects.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad2f64e394832fba509c1d2c79ede6