### PR TITLE
Add collection targeting to light effects

### DIFF
--- a/SkybrushUtil.py
+++ b/SkybrushUtil.py
@@ -887,6 +887,12 @@ def set_propertygroup_from_dict(pg, data):
                 setattr(pg, key, obj)
             continue
 
+        if key == "target_collection":
+            coll = bpy.data.collections.get(value)
+            if coll:
+                setattr(pg, key, coll)
+            continue
+
         current_value = getattr(pg, key)
 
         # ネストしたPropertyGroupの場合


### PR DESCRIPTION
## Summary
- allow light effects to target drones within a chosen collection
- expose collection picker in light effects panel
- handle collection targeting in JSON import/export
- add "Collection" option to the target selector

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad41829bdc832f953bd0b1014f829c