### PR TITLE
Use sets for available objects in color key utilities

### DIFF
--- a/SkybrushUtil.py
+++ b/SkybrushUtil.py
@@ -1119,9 +1119,9 @@ def apply_key(filepath, frame_offset, duration=0):
     from sbutil.color_key_utils import apply_color_keys_to_nearest
 
     drones_collection = bpy.data.collections.get("Drones")
-    available_objects = list(drones_collection.objects)
+    available_objects = set(drones_collection.objects)
     if duration != 0:
-        for obj in available_objects:
+        for obj in list(available_objects):
             mat = obj.active_material
             anim = mat.node_tree.animation_data
             if not anim or not anim.action:

--- a/sbutil/color_key_utils.py
+++ b/sbutil/color_key_utils.py
@@ -43,6 +43,7 @@ def _insert_color_keyframes(base_socket, keyframes_by_channel, frame_offset=0, n
 def apply_color_keys_to_nearest(location, keyframes_by_channel, available_objects, frame_offset=0, normalize_255=False):
     """Find the nearest object to ``location`` and apply color keyframes.
 
+    ``available_objects`` is a set of objects that have not yet been used.
     ``keyframes_by_channel`` should map channel indices (0=R,1=G,2=B,3=A)
     to sequences of ``(frame, value)`` pairs.
     """
@@ -67,7 +68,7 @@ def apply_color_keys_to_nearest(location, keyframes_by_channel, available_object
         normalize_255=normalize_255,
     )
 
-    available_objects.remove(nearest_obj)
+    available_objects.discard(nearest_obj)
     return available_objects
 
 
@@ -89,7 +90,7 @@ def apply_color_keys_from_key_data(
 
     drones_col = bpy.data.collections.get(collection_name)
     if drones_col:
-        available = list(drones_col.objects)
+        available = set(drones_col.objects)
         for entry in key_entries:
             available = apply_color_keys_to_nearest(
                 entry["location"],


### PR DESCRIPTION
## Summary
- track remaining objects as a set in color key utility functions
- discard used objects instead of list removal to simplify mutation handling
- initialize callers with sets and iterate over copies where mutation occurs

## Testing
- `python -m py_compile sbutil/color_key_utils.py SkybrushUtil.py sbutil/CSV2Vertex.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad5ba0a8f8832f959a0e9ca0a6dde6