### PR TITLE
Fix active vertex retrieval for Blender 4.3

### DIFF
--- a/sbutil/reflow_vertex.py
+++ b/sbutil/reflow_vertex.py
@@ -191,7 +191,9 @@ class MESH_OT_reflow_vertices(bpy.types.Operator):
             return {'FINISHED'}
 
         # ---- 端点決定 ----
-        active_bmv = bm.verts.active
+        active_bmv = bm.select_history.active
+        if not isinstance(active_bmv, bmesh.types.BMVert):
+            active_bmv = None
         if self.endpoint_mode == "EDGE_PATH":
             ep = endpoints_edge_path(sel)
             if ep is None:


### PR DESCRIPTION
## Summary
- use `bm.select_history.active` instead of deprecated `bm.verts.active`
- ensure active element is a vertex before using it

## Testing
- `python -m py_compile sbutil/reflow_vertex.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad6ad2d9cc832faa8ff9dad6c4f2d7