### PR TITLE
Fix AttributeError in reflow_vertex graph builder

### DIFF
--- a/sbutil/reflow_vertex.py
+++ b/sbutil/reflow_vertex.py
@@ -17,8 +17,6 @@ def build_selected_graph(bm_verts):
     # 隣接（選択内の辺）グラフを作る
     index_map = {v: i for i, v in enumerate(bm_verts)}
     adj = {i: set() for i in range(len(bm_verts))}
-    for e in bm_verts[0].link_faces.layers.face:  # dummy to silence linter
-        pass
     for e in [edge for v in bm_verts for edge in v.link_edges]:
         v0, v1 = e.verts
         if v0 in index_map and v1 in index_map:


### PR DESCRIPTION
## Summary
- remove invalid link_faces.layers access causing AttributeError
- simplify edge adjacency graph construction

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile sbutil/reflow_vertex.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad72bb4ad8832faed6c9cf5e07d9aa