### PR TITLE
Clamp text hash to 32-bit for Blender ID properties

### DIFF
--- a/sbutil/light_effects.py
+++ b/sbutil/light_effects.py
@@ -25,6 +25,7 @@ from collections.abc import Callable, Iterable, Sequence
 from functools import partial
 from operator import itemgetter
 from typing import cast, Optional
+import ctypes
 
 from mathutils import Matrix, Vector
 from mathutils.bvhtree import BVHTree
@@ -102,7 +103,7 @@ def initialize_color_function(pg) -> None:
     if getattr(pg, "color_function_text", None):
         text = pg.color_function_text
         source = text.as_string()
-        text_hash = hash(source)
+        text_hash = ctypes.c_int(hash(source)).value
         if text_hash != st.get("text_hash"):
             reset_state()
             st["text_hash"] = text_hash


### PR DESCRIPTION
## Summary
- cast color function text hash to 32-bit signed integer before storing in ID properties

## Testing
- `python -m py_compile sbutil/light_effects.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8166ff24832fb7d1b46ffba616b6