### PR TITLE
Use stable hash for color function text

### DIFF
--- a/sbutil/light_effects.py
+++ b/sbutil/light_effects.py
@@ -25,7 +25,7 @@ from collections.abc import Callable, Iterable, Sequence
 from functools import partial
 from operator import itemgetter
 from typing import cast, Optional
-import ctypes
+import hashlib
 
 from mathutils import Matrix, Vector
 from mathutils.bvhtree import BVHTree
@@ -134,7 +134,7 @@ def initialize_color_function(pg) -> None:
     if getattr(pg, "color_function_text", None):
         text = pg.color_function_text
         source = text.as_string()
-        text_hash = ctypes.c_int(hash(source)).value
+        text_hash = hashlib.sha256(source.encode()).hexdigest()
         if text_hash != st.get("text_hash"):
             reset_state()
             st["text_hash"] = text_hash


### PR DESCRIPTION
## Summary
- Replace non-deterministic `hash()` with SHA-256 digest for color function text
- Store and compare digest strings instead of integer hashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae8871d754832fa81e293e7f7982a8