### PR TITLE
Skip reserved names in color function schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Blender add-on for transferring keyframes and light effects.
 - Recalculate transitions while preserving material color keys.
 - Drive light effects with ColorRamps or custom Python functions.
 
+## Custom color functions
+
+Custom Python modules may define uppercase constants that show up as
+configuration options in Blender. The names of these constants must not clash
+with existing RNA properties of the light effect. Names such as `name`, `type`,
+`id_data` or `rna_type` are reserved and will be ignored if defined.
+
 ## Updating
 
 In **Edit > Preferences > Add-ons**, open the Skybrush Util entry and use the


### PR DESCRIPTION
## Summary
- ignore constants that collide with LightEffect RNA properties when creating dynamic schema
- document reserved constant names for custom color functions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae888d2828832fa8bd64e840ea8f57