### PR TITLE
Fix embedded color functions not applied in Apply_on_color

### DIFF
--- a/sbutil/light_effects.py
+++ b/sbutil/light_effects.py
@@ -276,13 +276,16 @@ class PatchedLightEffect(PropertyGroup):
     )
     @property
     def color_function_ref(self) -> Optional[Callable]:
-        if self.type != "FUNCTION" or not self.color_function:
+        if self.type != "FUNCTION":
+            return None
+        function_name = getattr(getattr(self, "color_function", None), "name", None)
+        if not function_name:
             return None
         st = get_state(self)
         module = st.get("module")
         if module is None:
             return None
-        return getattr(module, self.color_function.name, None)
+        return getattr(module, function_name, None)
 
     def draw_color_function_config(self, layout) -> None:
         """Draw UI controls for dynamically discovered config variables."""


### PR DESCRIPTION
## Summary
- fix LightEffect.color_function_ref to return embedded function references

## Testing
- `python -m pytest`
- `python -m py_compile sbutil/light_effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae90be65e0832f9b48034a0b484a14