### PR TITLE
Fix embedded color functions not applied in Apply_on_color

### DIFF
--- a/sbutil/light_effects.py
+++ b/sbutil/light_effects.py
@@ -198,6 +198,9 @@ def initialize_color_function(pg) -> None:
         return
 
     ap = abspath(pg.color_function.path)
+    if not ap.lower().endswith(".py"):
+        reset_state()
+        return
     if ap != st.get("absolute_path", ""):
         reset_state()
         st["absolute_path"] = ap
@@ -276,13 +279,19 @@ class PatchedLightEffect(PropertyGroup):
     )
     @property
     def color_function_ref(self) -> Optional[Callable]:
-        if self.type != "FUNCTION" or not self.color_function:
+        if self.type != "FUNCTION":
+            return None
+        function_name = getattr(getattr(self, "color_function", None), "name", None)
+        if not function_name:
             return None
         st = get_state(self)
         module = st.get("module")
         if module is None:
+            initialize_color_function(self)
+            module = st.get("module")
+        if module is None:
             return None
-        return getattr(module, self.color_function.name, None)
+        return getattr(module, function_name, None)
 
     def draw_color_function_config(self, layout) -> None:
         """Draw UI controls for dynamically discovered config variables."""
@@ -391,9 +400,15 @@ class PatchedLightEffect(PropertyGroup):
             elif output_type == "GROUP":
                 outputs = [output_function(idx, 0, 0) for idx in range(num_positions)]
             elif output_type == "CUSTOM":
-                absolute_path = abspath(output_function.path)
-                module = load_module(absolute_path) if absolute_path else None
-                if self.output_function.name:
+                module = get_state(self).get("module")
+                if module is None:
+                    path = output_function.path
+                    module = (
+                        load_module(abspath(path))
+                        if path and path.lower().endswith(".py")
+                        else None
+                    )
+                if self.output_function.name and module:
                     fn = getattr(module, self.output_function.name)
                     outputs = [
                         fn(
@@ -859,10 +874,15 @@ class PatchedLightEffectsPanel(Panel):  # pragma: no cover - Blender UI code
                 elif entry.type == "FUNCTION":
                     box = self.layout.box()
                     row = box.row(align=True)
-                    row.prop(entry.color_function, "path", text="")
-                    row.operator(EmbedColorFunctionOperator.bl_idname, text="Embed")
                     if entry.color_function_text:
-                        row.operator(UnembedColorFunctionOperator.bl_idname, text="Unembed")
+                        row.operator(
+                            UnembedColorFunctionOperator.bl_idname, text="Unembed"
+                        )
+                    else:
+                        row.prop(entry.color_function, "path", text="")
+                        row.operator(
+                            EmbedColorFunctionOperator.bl_idname, text="Embed"
+                        )
                     box.prop(entry.color_function, "name", text="")
                     box.prop(entry, "color_function_text", text="")
                     entry.draw_color_function_config(box)


### PR DESCRIPTION
## Summary
- load color function module on demand so embedded scripts override file paths
- hide file-path field when a script is embedded, keeping function name and text visible
- ignore non-Python files when loading color or output function modules
- reuse module from embedded color scripts for custom output functions

## Testing
- `python -m pytest`
- `python -m py_compile sbutil/light_effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae90be65e0832f9b48034a0b484a14