### PR TITLE
Support rotation, scale and material dynamic properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ configuration options in Blender. The names of these constants must not clash
 with existing RNA properties of the light effect. Names such as `name`, `type`,
 `id_data` or `rna_type` are reserved and will be ignored if defined.
 
+Constants may also carry special suffixes that determine how their values are
+interpreted:
+
+- `_COLOR` – display the value as a color picker.
+- `_POS` – interpret the value as an XYZ position. An additional property
+  named `<name>_object` is created to allow referencing a Blender object. When
+  set, the object's world position overrides the constant.
+- `_ROT` – similar to `_POS`, but uses the object's rotation in Euler angles.
+- `_SCL` – similar to `_POS`, but uses the object's scale.
+- `_MAT` – similar to `_POS`, but uses the base color of the object's first
+  material (if any).
+
 ## Updating
 
 In **Edit > Preferences > Add-ons**, open the Skybrush Util entry and use the


### PR DESCRIPTION
## Summary
- allow custom color functions to reference object rotation, scale and material colors via `_ROT`, `_SCL` and `_MAT`
- document new dynamic property suffixes

## Testing
- `python -m py_compile sbutil/light_effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68afbd3491b0832f94f8ee60f885b498